### PR TITLE
Add gcs SSE-KMS support

### DIFF
--- a/generated.go
+++ b/generated.go
@@ -29,7 +29,9 @@ const (
 	pairDefaultStoragePairs = "gcs_default_storage_pairs"
 	// EncryptionKey is the customer's 32-byte AES-256 key
 	pairEncryptionKey = "gcs_encryption_key"
-	// KmsKeyName is the Cloud KMS key resource. For example, projects/my-pet-project/locations/us-east1/keyRings/my-key-ring/cryptoKeys/my-key.
+	// KmsKeyName is the Cloud KMS key resource. For example, `projects/my-pet-project/locations/us-east1/keyRings/my-key-ring/cryptoKeys/my-key`.
+	//
+	// Refer to https://cloud.google.com/storage/docs/encryption/using-customer-managed-keys#add-object-key for more details.
 	pairKmsKeyName = "gcs_kms_key_name"
 	// ProjectID
 	pairProjectID = "gcs_project_id"
@@ -92,7 +94,9 @@ func WithEncryptionKey(v []byte) Pair {
 }
 
 // WithKmsKeyName will apply kms_key_name value to Options
-// KmsKeyName is the Cloud KMS key resource. For example, projects/my-pet-project/locations/us-east1/keyRings/my-key-ring/cryptoKeys/my-key.
+// KmsKeyName is the Cloud KMS key resource. For example, `projects/my-pet-project/locations/us-east1/keyRings/my-key-ring/cryptoKeys/my-key`.
+//
+// Refer to https://cloud.google.com/storage/docs/encryption/using-customer-managed-keys#add-object-key for more details.
 func WithKmsKeyName(v string) Pair {
 	return Pair{
 		Key:   pairKmsKeyName,

--- a/generated.go
+++ b/generated.go
@@ -29,6 +29,8 @@ const (
 	pairDefaultStoragePairs = "gcs_default_storage_pairs"
 	// EncryptionKey is the customer's 32-byte AES-256 key
 	pairEncryptionKey = "gcs_encryption_key"
+	// KmsKeyName is the Cloud KMS key resource. For example, projects/my-pet-project/locations/us-east1/keyRings/my-key-ring/cryptoKeys/my-key.
+	pairKmsKeyName = "gcs_kms_key_name"
 	// ProjectID
 	pairProjectID = "gcs_project_id"
 	// StorageClass
@@ -85,6 +87,15 @@ func WithDefaultStoragePairs(v DefaultStoragePairs) Pair {
 func WithEncryptionKey(v []byte) Pair {
 	return Pair{
 		Key:   pairEncryptionKey,
+		Value: v,
+	}
+}
+
+// WithKmsKeyName will apply kms_key_name value to Options
+// KmsKeyName is the Cloud KMS key resource. For example, projects/my-pet-project/locations/us-east1/keyRings/my-key-ring/cryptoKeys/my-key.
+func WithKmsKeyName(v string) Pair {
+	return Pair{
+		Key:   pairKmsKeyName,
 		Value: v,
 	}
 }
@@ -703,6 +714,8 @@ type pairStorageWrite struct {
 	EncryptionKey    []byte
 	HasIoCallback    bool
 	IoCallback       func([]byte)
+	HasKmsKeyName    bool
+	KmsKeyName       string
 	HasStorageClass  bool
 	StorageClass     string
 	// Generated pairs
@@ -730,6 +743,9 @@ func (s *Storage) parsePairStorageWrite(opts []Pair) (pairStorageWrite, error) {
 		case "io_callback":
 			result.HasIoCallback = true
 			result.IoCallback = v.Value.(func([]byte))
+		case pairKmsKeyName:
+			result.HasKmsKeyName = true
+			result.KmsKeyName = v.Value.(string)
 		case pairStorageClass:
 			result.HasStorageClass = true
 			result.StorageClass = v.Value.(string)

--- a/service.toml
+++ b/service.toml
@@ -23,7 +23,7 @@ description = "is the customer's 32-byte AES-256 key"
 
 [pairs.kms_key_name]
 type = "string"
-description = "is the Cloud KMS key resource. For example, projects/my-pet-project/locations/us-east1/keyRings/my-key-ring/cryptoKeys/my-key."
+description = "is the Cloud KMS key resource. For example, `projects/my-pet-project/locations/us-east1/keyRings/my-key-ring/cryptoKeys/my-key`.\n\nRefer to https://cloud.google.com/storage/docs/encryption/using-customer-managed-keys#add-object-key for more details."
 
 [pairs.default_service_pairs]
 type = "DefaultServicePairs"

--- a/service.toml
+++ b/service.toml
@@ -15,11 +15,15 @@ optional = ["list_mode"]
 optional = ["offset", "io_callback", "size", "encryption_key"]
 
 [namespace.storage.op.write]
-optional = ["content_md5", "content_type", "io_callback", "storage_class", "encryption_key"]
+optional = ["content_md5", "content_type", "io_callback", "storage_class", "encryption_key", "kms_key_name"]
 
 [pairs.encryption_key]
 type = "byte_array"
 description = "is the customer's 32-byte AES-256 key"
+
+[pairs.kms_key_name]
+type = "string"
+description = "is the Cloud KMS key resource. For example, projects/my-pet-project/locations/us-east1/keyRings/my-key-ring/cryptoKeys/my-key."
 
 [pairs.default_service_pairs]
 type = "DefaultServicePairs"

--- a/storage.go
+++ b/storage.go
@@ -193,6 +193,9 @@ func (s *Storage) write(ctx context.Context, path string, r io.Reader, size int6
 	if opt.HasStorageClass {
 		w.StorageClass = opt.StorageClass
 	}
+	if opt.HasKmsKeyName {
+		w.KMSKeyName = opt.KmsKeyName
+	}
 	if opt.HasIoCallback {
 		r = iowrap.CallbackReader(r, opt.IoCallback)
 	}


### PR DESCRIPTION
Actually gcs's SSE-KMS support [encrypt an individual object with a Cloud KMS key](https://cloud.google.com/storage/docs/encryption/using-customer-managed-keys#add-object-key) (It's a parameter, not a header 👀). I added it.