### PR TITLE
Allow GCS client to use credentials from the environment if needed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,5 @@ require (
 	github.com/beyondstorage/go-integration-test/v4 v4.2.0
 	github.com/beyondstorage/go-storage/v4 v4.4.0
 	github.com/google/uuid v1.3.0
-	golang.org/x/oauth2 v0.0.0-20210628180205-a41e5a781914
 	google.golang.org/api v0.50.0
 )

--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,6 @@ require (
 	github.com/beyondstorage/go-integration-test/v4 v4.2.0
 	github.com/beyondstorage/go-storage/v4 v4.4.0
 	github.com/google/uuid v1.3.0
+	golang.org/x/oauth2 v0.0.0-20210628180205-a41e5a781914
 	google.golang.org/api v0.50.0
 )

--- a/service.go
+++ b/service.go
@@ -2,11 +2,9 @@ package gcs
 
 import (
 	"context"
-
-	"google.golang.org/api/iterator"
-
 	ps "github.com/beyondstorage/go-storage/v4/pairs"
 	typ "github.com/beyondstorage/go-storage/v4/types"
+	"google.golang.org/api/iterator"
 )
 
 func (s *Service) create(ctx context.Context, name string, opt pairServiceCreate) (store typ.Storager, err error) {
@@ -47,7 +45,6 @@ func (s *Service) list(ctx context.Context, opt pairServiceList) (it *typ.Storag
 
 func (s *Service) nextStoragePage(ctx context.Context, page *typ.StoragerPage) error {
 	it := s.service.Buckets(ctx, s.projectID)
-
 	for {
 		bucket, err := it.Next()
 		if err == iterator.Done {
@@ -56,12 +53,10 @@ func (s *Service) nextStoragePage(ctx context.Context, page *typ.StoragerPage) e
 		if err != nil {
 			return err
 		}
-
 		store, err := s.newStorage(ps.WithName(bucket.Name))
 		if err != nil {
 			return err
 		}
-
 		page.Data = append(page.Data, store)
 	}
 }

--- a/utils.go
+++ b/utils.go
@@ -115,14 +115,14 @@ func newServicer(pairs ...typ.Pair) (srv *Service, err error) {
 		return nil, services.PairUnsupportedError{Pair: ps.WithCredential(opt.Credential)}
 	}
 
-	credOptions := []option.ClientOption{
+	clientOptions := []option.ClientOption{
 		option.WithScopes(gs.ScopeFullControl),
 	}
 	if len(credJSON) > 0 {
-		credOptions = append(credOptions, option.WithCredentialsJSON(credJSON))
+		clientOptions = append(clientOptions, option.WithCredentialsJSON(credJSON))
 	}
 
-	transport, err := googleHttp.NewTransport(ctx, hc.Transport, credOptions...)
+	transport, err := googleHttp.NewTransport(ctx, hc.Transport, clientOptions...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When running in GCP environment, the credentials can be fetched automatically by the GCP SDK, and there is no need to specify any additional JSON/env variables (https://cloud.google.com/docs/authentication/production#automatically).